### PR TITLE
cierre de conexiones y caches de front

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ target
 .settings/
 bin
 output
+.idea/
+*.iml
+CLAUDE.md

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ output
 .idea/
 *.iml
 CLAUDE.md
+build.*.properties
+!build.USERNAME.properties

--- a/build.abastos.properties
+++ b/build.abastos.properties
@@ -1,0 +1,12 @@
+rolsac.target=dgtic-rolsac
+project.author=CAIB-DGTIC-ABASTOS
+
+# Directori de deploy
+deploy.dir=C:\\caib\\aplicacions\\jboss-5.2-gusite-des\\server\\jboss05\\deploycaib
+jbossServiceDeploy.dir=C:\\caib\\aplicacions\\jboss-5.2-gusite-des\\server\\jboss05\\deploycaib
+
+# SVN
+mvn.repository.path=C:\\Users\\u93187\\.m2\\repository\\
+
+# Log del sql generado
+hibernate.show_sql=false

--- a/moduls/front/htdocs/WEB-INF/ehcache.xml
+++ b/moduls/front/htdocs/WEB-INF/ehcache.xml
@@ -31,19 +31,19 @@
     <cache name="cacheMicrositeMenu"
         maxElementsInMemory="1000"
         eternal="false"
-        timeToLiveSeconds="60"
+        timeToLiveSeconds="1"
         overflowToDisk="false"/>
 
     <cache name="plantillas"
         maxElementsInMemory="500"
         eternal="false"
-        timeToLiveSeconds="60"
+        timeToLiveSeconds="1"
         overflowToDisk="false"/>
 
     <cache name="cacheMicrosite"
         maxElementsInMemory="200"
         eternal="false"
-        timeToLiveSeconds="60"
+        timeToLiveSeconds="1"
         overflowToDisk="false"/>
 
 </ehcache>

--- a/moduls/front/htdocs/WEB-INF/ehcache.xml
+++ b/moduls/front/htdocs/WEB-INF/ehcache.xml
@@ -28,4 +28,10 @@
         timeToLiveSeconds="600"
         overflowToDisk="false"/>
 
+    <cache name="cacheMicrositeMenu"
+        maxElementsInMemory="1000"
+        eternal="false"
+        timeToLiveSeconds="600"
+        overflowToDisk="false"/>
+
 </ehcache>

--- a/moduls/front/htdocs/WEB-INF/ehcache.xml
+++ b/moduls/front/htdocs/WEB-INF/ehcache.xml
@@ -31,7 +31,7 @@
     <cache name="cacheMicrositeMenu"
         maxElementsInMemory="1000"
         eternal="false"
-        timeToLiveSeconds="600"
+        timeToLiveSeconds="60"
         overflowToDisk="false"/>
 
 </ehcache>

--- a/moduls/front/htdocs/WEB-INF/ehcache.xml
+++ b/moduls/front/htdocs/WEB-INF/ehcache.xml
@@ -34,4 +34,16 @@
         timeToLiveSeconds="60"
         overflowToDisk="false"/>
 
+    <cache name="plantillas"
+        maxElementsInMemory="500"
+        eternal="false"
+        timeToLiveSeconds="60"
+        overflowToDisk="false"/>
+
+    <cache name="cacheMicrosite"
+        maxElementsInMemory="200"
+        eternal="false"
+        timeToLiveSeconds="60"
+        overflowToDisk="false"/>
+
 </ehcache>

--- a/moduls/front/src/es/caib/gusite/front/general/BaseViewController.java
+++ b/moduls/front/src/es/caib/gusite/front/general/BaseViewController.java
@@ -101,7 +101,6 @@ public abstract class BaseViewController extends FrontController {
 	 * @see
 	 */
 	public void configureLayoutView(final String uri, final Idioma lang, final LayoutView view, final String pcampa, final String uriContenido) throws ExceptionFrontMicro {
-
 		/* El idioma ya viene fijado en la URI */
 		String idi = lang.getLang().toUpperCase();
 		view.setIdioma(idi);

--- a/moduls/front/src/es/caib/gusite/front/general/BaseViewController.java
+++ b/moduls/front/src/es/caib/gusite/front/general/BaseViewController.java
@@ -165,8 +165,7 @@ public abstract class BaseViewController extends FrontController {
 
 		Microsite microsite = null;
 		try {
-			DelegateBase _delegateBase = new DelegateBase();
-			microsite = _delegateBase.obtenerMicrositebyUri(uri, lang.getLang());
+			microsite = delegateBase.obtenerMicrositebyUri(uri, lang.getLang());
 
 			if (microsite == null) {
 				throw new ExceptionFrontMicro(" [Configuracion microsite]: Se debe indicar algún microsite");

--- a/moduls/front/src/es/caib/gusite/front/general/BaseViewController.java
+++ b/moduls/front/src/es/caib/gusite/front/general/BaseViewController.java
@@ -66,6 +66,9 @@ public abstract class BaseViewController extends FrontController {
 	}
 
 	@Autowired
+	private DelegateBase delegateBase;
+
+	@Autowired
 	private OrganigramaProvider organigramaProvider;
 
 	@Autowired
@@ -516,9 +519,7 @@ public abstract class BaseViewController extends FrontController {
 	 * @param request
 	 */
 	private void cargarMenu(final LayoutView view, final String uriContenido) throws ExceptionFrontMicro {
-		DelegateBase delegateBase;
 		try {
-			delegateBase = new DelegateBase();
 			view.setMenu(delegateBase.obtenerMainMenu(view.getMicrosite().getId(), view.getLang().getLang(), uriContenido));
 		} catch (DelegateException e) {
 			throw new ExceptionFrontMicro(e);

--- a/moduls/front/src/es/caib/gusite/front/general/DelegateBase.java
+++ b/moduls/front/src/es/caib/gusite/front/general/DelegateBase.java
@@ -30,6 +30,8 @@ import es.caib.gusite.micropersistence.delegate.MenuDelegate;
 import es.caib.gusite.micropersistence.delegate.MicrositeDelegate;
 import es.caib.gusite.micropersistence.delegate.NoticiaDelegate;
 import es.caib.gusite.micropersistence.delegate.TiposervicioDelegate;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Component;
 //import es.caib.gusite.plugins.rolsac.APIUtil;
 //import es.caib.rolsac.api.v2.edifici.EdificiCriteria;
 //import es.caib.rolsac.api.v2.rolsac.RolsacQueryService;
@@ -39,10 +41,11 @@ import es.caib.gusite.micropersistence.delegate.TiposervicioDelegate;
 /**
  * Manejador de obtener objetos listos para ser visualizados en la web. Utiliza
  * ObjectCache para ir cacheando todos los objetos que se van demandando.
- * 
+ *
  * @author Indra
- * 
+ *
  */
+@Component
 public class DelegateBase {
 
 	protected static Log _log = LogFactory.getLog(DelegateBase.class);
@@ -103,6 +106,7 @@ public class DelegateBase {
 	 * @return ArrayList con objetos "Menufront"
 	 * @throws Exception
 	 */
+	@Cacheable(value = "cacheMicrositeMenu", key = "#idmicrosite+ '-' +#idioma")
 	public List<MenuFront> obtenerMainMenu(Long idmicrosite, String idioma, String uriContenido) throws DelegateException {
 		List<MenuFront> listamenu = this.montarmenu(idmicrosite, idioma, uriContenido);
 		return listamenu;

--- a/moduls/front/src/es/caib/gusite/front/general/DelegateBase.java
+++ b/moduls/front/src/es/caib/gusite/front/general/DelegateBase.java
@@ -84,6 +84,7 @@ public class DelegateBase {
 	 * @return Microsites
 	 * @throws ExceptionFrontMicro
 	 */
+	@Cacheable(value = "cacheMicrosite", key = "#uri + '-' + #idioma", unless = "#result == null")
 	public Microsite obtenerMicrositebyUri(String uri, String idioma) throws DelegateException {
 		MicrositeDelegate microdel = DelegateUtil.getMicrositeDelegate();
 

--- a/moduls/front/src/es/caib/gusite/front/general/DelegateBase.java
+++ b/moduls/front/src/es/caib/gusite/front/general/DelegateBase.java
@@ -30,6 +30,9 @@ import es.caib.gusite.micropersistence.delegate.MenuDelegate;
 import es.caib.gusite.micropersistence.delegate.MicrositeDelegate;
 import es.caib.gusite.micropersistence.delegate.NoticiaDelegate;
 import es.caib.gusite.micropersistence.delegate.TiposervicioDelegate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
 //import es.caib.gusite.plugins.rolsac.APIUtil;
@@ -49,6 +52,9 @@ import org.springframework.stereotype.Component;
 public class DelegateBase {
 
 	protected static Log _log = LogFactory.getLog(DelegateBase.class);
+
+	@Autowired(required = false)
+	private CacheManager cacheManager;
 
 	public DelegateBase() {
 	}
@@ -84,13 +90,21 @@ public class DelegateBase {
 	 * @return Microsites
 	 * @throws ExceptionFrontMicro
 	 */
-	@Cacheable(value = "cacheMicrosite", key = "#uri + '-' + #idioma", unless = "#result == null")
 	public Microsite obtenerMicrositebyUri(String uri, String idioma) throws DelegateException {
+		if (cacheManager != null) {
+			Cache cache = cacheManager.getCache("cacheMicrosite");
+			Cache.ValueWrapper cached = cache.get(uri + '-' + idioma);
+			if (cached != null) {
+				return (Microsite) cached.get();
+			}
+		}
 		MicrositeDelegate microdel = DelegateUtil.getMicrositeDelegate();
-
 		Microsite micro = microdel.obtenerMicrositebyUri(uri);
 		if (micro != null) {
 			micro.setIdi(idioma);
+			if (cacheManager != null) {
+				cacheManager.getCache("cacheMicrosite").put(uri + '-' + idioma, micro);
+			}
 		}
 		return micro;
 

--- a/moduls/front/src/es/caib/gusite/front/service/TemplateDataService.java
+++ b/moduls/front/src/es/caib/gusite/front/service/TemplateDataService.java
@@ -18,6 +18,7 @@ public class TemplateDataService {
 
 	protected static Log log = LogFactory.getLog(TemplateDataService.class);
 
+	@Cacheable(value = "plantillas", unless = "#result == null")
 	public PersonalizacionPlantilla getPlantilla(final Long idPerPla) throws ExceptionFront {
 		try {
 			final PersonalizacionPlantillaDelegate ppdel = DelegateUtil.getPersonalizacionPlantillaDelegate();

--- a/moduls/front/src/es/caib/gusite/front/service/TemplateDataService.java
+++ b/moduls/front/src/es/caib/gusite/front/service/TemplateDataService.java
@@ -4,6 +4,9 @@ import java.util.List;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
@@ -18,11 +21,21 @@ public class TemplateDataService {
 
 	protected static Log log = LogFactory.getLog(TemplateDataService.class);
 
-	@Cacheable(value = "plantillas", unless = "#result == null")
+	@Autowired
+	private CacheManager cacheManager;
+
 	public PersonalizacionPlantilla getPlantilla(final Long idPerPla) throws ExceptionFront {
+		Cache cache = cacheManager.getCache("plantillas");
+		Cache.ValueWrapper cached = cache.get(idPerPla);
+		if (cached != null) {
+			return (PersonalizacionPlantilla) cached.get();
+		}
 		try {
 			final PersonalizacionPlantillaDelegate ppdel = DelegateUtil.getPersonalizacionPlantillaDelegate();
 			final PersonalizacionPlantilla ret = ppdel.obtenerPersonalizacionPlantilla(idPerPla);
+			if (ret != null) {
+				cache.put(idPerPla, ret);
+			}
 			return ret;
 
 		} catch (final DelegateException e) {

--- a/moduls/micropersistence/src/es/caib/gusite/micropersistence/ejb/HibernateTrulyStatelessEJB.java
+++ b/moduls/micropersistence/src/es/caib/gusite/micropersistence/ejb/HibernateTrulyStatelessEJB.java
@@ -230,34 +230,42 @@ public abstract class HibernateTrulyStatelessEJB implements SessionBean {
 	private Long grabarAuditoria(Auditoria auditoria) {
 
 		Session session = this.getSession();
-		
+		Transaction tx = null;
+
 		try {
-			
-			Transaction tx = session.beginTransaction();
-			
+
+			tx = session.beginTransaction();
+
 			// El caso del "antiguo microsite 0" (no microsite asociado) hay que tratarlo como si fuera null ahora.
 			// Si no, cuando se va a grabar ua auditoria la PK 0 no se encuentra en la tabla de Microsites y se
 			// produce un error de integridad por la FK establecida en la tabla de auditoría.
 			if (auditoria.getIdmicrosite() != null && auditoria.getIdmicrosite() == 0L)
 				auditoria.setIdmicrosite(null);
-			
+
 			auditoria.setFecha(new Date());
 			auditoria.setUsuario(this.getUsuario(session).getUsername());
 			session.saveOrUpdate(auditoria);
 			session.flush();
-			
+
 			tx.commit();
-			
+
 			return auditoria.getId();
 
 		} catch (HibernateException he) {
-			
+
+			if (tx != null) {
+				try {
+					tx.rollback();
+				} catch (HibernateException rbe) {
+					log.error("Rollback failed on audit", rbe);
+				}
+			}
 			throw new EJBException(he);
-			
+
 		} finally {
-			
+
 			this.close(session);
-			
+
 		}
 		
 	}

--- a/moduls/micropersistence/src/es/caib/gusite/micropersistence/ejb/NoticiaFacadeEJB.java
+++ b/moduls/micropersistence/src/es/caib/gusite/micropersistence/ejb/NoticiaFacadeEJB.java
@@ -140,10 +140,10 @@ public abstract class NoticiaFacadeEJB extends HibernateEJB implements DominioIn
 
 		final Session session = this.getSession();
 		final boolean nuevo = (noticia.getId() == null) ? true : false;
-		final Transaction tx = session.beginTransaction();
 
 		try {
 
+			final Transaction tx = session.beginTransaction();
 			final ArchivoDelegate archivoDelegate = DelegateUtil.getArchivoDelegate();
 			Noticia noticiaOriginal = null;
 			Archivo imagenNoticia = null;
@@ -302,15 +302,15 @@ public abstract class NoticiaFacadeEJB extends HibernateEJB implements DominioIn
 
 		} catch (final HibernateException he) {
 
-			tx.rollback();
-			session.close();
 			throw new EJBException(he);
 
 		} catch (final DelegateException e) {
 
-			tx.rollback();
-			session.close();
 			throw new EJBException(e);
+
+		} finally {
+
+			this.close(session);
 
 		}
 

--- a/moduls/micropersistence/src/es/caib/gusite/micropersistence/ejb/PersonalizacionPlantillaFacadeEJB.java
+++ b/moduls/micropersistence/src/es/caib/gusite/micropersistence/ejb/PersonalizacionPlantillaFacadeEJB.java
@@ -207,8 +207,15 @@ public abstract class PersonalizacionPlantillaFacadeEJB extends HibernateTrulySt
 				criteria.addOrder(Order.desc(orden.substring(1)));
 			}
 
-			return criteria.list();
-
+			List<PersonalizacionPlantilla> instances = criteria.list();
+			// forzar carga de colecciones para poder cerrar la conexión
+			// sin riesgo a LazyInitializationException
+			for (PersonalizacionPlantilla instance : instances) {
+				instance.getTipos().size();
+				instance.getContenidos().size();
+				instance.getComponentes().size();
+			}
+			return instances;
 		} catch (final HibernateException re) {
 			log.error("get failed", re);
 			throw new EJBException(re);

--- a/moduls/micropersistence/src/es/caib/gusite/micropersistence/ejb/PersonalizacionPlantillaFacadeEJB.java
+++ b/moduls/micropersistence/src/es/caib/gusite/micropersistence/ejb/PersonalizacionPlantillaFacadeEJB.java
@@ -54,7 +54,6 @@ public abstract class PersonalizacionPlantillaFacadeEJB extends HibernateTrulySt
 			final PersonalizacionPlantilla ret = (PersonalizacionPlantilla) session.get(PersonalizacionPlantilla.class,
 					session.save(instance));
 			session.flush();
-			session.close();
 			grabarAuditoria(ret, Auditoria.CREAR);
 			return ret;
 
@@ -62,6 +61,7 @@ public abstract class PersonalizacionPlantillaFacadeEJB extends HibernateTrulySt
 			log.error("persist failed", re);
 			throw new EJBException(re);
 		} finally {
+			this.close(session);
 			log.debug("finished add PersonalizacionPlantilla instance");
 		}
 	}
@@ -80,13 +80,13 @@ public abstract class PersonalizacionPlantillaFacadeEJB extends HibernateTrulySt
 			// Now update the data.
 			session.update(instance);
 			session.flush();
-			session.close();
 			grabarAuditoria(instance, Auditoria.MODIFICAR);
 
 		} catch (final HibernateException e) {
 			log.error("update failed", e);
 			throw new EJBException(e);
 		} finally {
+			this.close(session);
 			log.debug("finished updating PersonalizacionPlantilla instance");
 		}
 	}
@@ -104,13 +104,13 @@ public abstract class PersonalizacionPlantillaFacadeEJB extends HibernateTrulySt
 		try {
 			session.delete(instance);
 			session.flush();
-			session.close();
 			grabarAuditoria(instance, Auditoria.ELIMINAR);
 
 		} catch (final HibernateException e) {
 			log.error("delete failed", e);
 			throw new EJBException(e);
 		} finally {
+			this.close(session);
 			log.debug("finished deleting PersonalizacionPlantilla instance");
 		}
 	}
@@ -134,12 +134,13 @@ public abstract class PersonalizacionPlantillaFacadeEJB extends HibernateTrulySt
 			} else {
 				log.debug("get successful, instances found");
 			}
-			session.close();
 			return instances;
 
 		} catch (final HibernateException re) {
 			log.error("get failed", re);
 			throw new EJBException(re);
+		} finally {
+			this.close(session);
 		}
 	}
 
@@ -161,12 +162,13 @@ public abstract class PersonalizacionPlantillaFacadeEJB extends HibernateTrulySt
 			} else {
 				log.debug("get successful, instance found");
 			}
-			session.close();
 			return instance;
 
 		} catch (final HibernateException re) {
 			log.error("get failed", re);
 			throw new EJBException(re);
+		} finally {
+			this.close(session);
 		}
 	}
 
@@ -192,8 +194,8 @@ public abstract class PersonalizacionPlantillaFacadeEJB extends HibernateTrulySt
 			final Integer pagina, final Integer max) {
 
 		final String orden = (ordre == null) ? "Aid" : ordre;
+		final Session session = this.getSession();
 		try {
-			final Session session = this.getSession();
 			final Criteria criteria = session.createCriteria(PersonalizacionPlantilla.class);
 			criteria.add(Restrictions.eq("microsite.id", microsite));
 			criteria.setMaxResults(max);
@@ -205,12 +207,13 @@ public abstract class PersonalizacionPlantillaFacadeEJB extends HibernateTrulySt
 				criteria.addOrder(Order.desc(orden.substring(1)));
 			}
 
-			final List<PersonalizacionPlantilla> list = criteria.list();
-			return list;
+			return criteria.list();
 
 		} catch (final HibernateException re) {
 			log.error("get failed", re);
 			throw new EJBException(re);
+		} finally {
+			this.close(session);
 		}
 	}
 

--- a/moduls/micropersistence/src/es/caib/gusite/micropersistence/ejb/PlantillaFacadeEJB.java
+++ b/moduls/micropersistence/src/es/caib/gusite/micropersistence/ejb/PlantillaFacadeEJB.java
@@ -72,14 +72,16 @@ public abstract class PlantillaFacadeEJB extends HibernateTrulyStatelessEJB {
 	 */
 	public void actualizarPlantilla(Plantilla instance) {
 		log.debug("updating Plantilla instance");
+		Session session = this.getSession();
 		try {
 			// Now update the data.
-			this.getSession().update(instance);
+			session.update(instance);
 			this.grabarAuditoria(instance, Auditoria.MODIFICAR);
 		} catch (HibernateException e) {
 			log.error("update failed", e);
 			throw new EJBException(e);
 		} finally {
+			this.close(session);
 			log.debug("finished updating Plantilla instance");
 		}
 	}
@@ -92,13 +94,15 @@ public abstract class PlantillaFacadeEJB extends HibernateTrulyStatelessEJB {
 	 */
 	public void borrarPlantilla(Plantilla instance) {
 		log.debug("deleting Plantilla instance");
+		Session session = this.getSession();
 		try {
-			this.getSession().delete(instance);
+			session.delete(instance);
 			this.grabarAuditoria(instance, Auditoria.ELIMINAR);
 		} catch (HibernateException e) {
 			log.error("delete failed", e);
 			throw new EJBException(e);
 		} finally {
+			this.close(session);
 			log.debug("finished deleting Plantilla instance");
 		}
 	}
@@ -112,8 +116,9 @@ public abstract class PlantillaFacadeEJB extends HibernateTrulyStatelessEJB {
 	@SuppressWarnings("unchecked")
 	public List<Plantilla> listarPlantilla() {
 		log.debug("listar Plantilla");
+		Session session = this.getSession();
 		try {
-			List<Plantilla> instances = this.getSession()
+			List<Plantilla> instances = session
 					.createCriteria(Plantilla.class).addOrder(Order.asc("nombre")).list();
 			if (instances.size() == 0) {
 				log.debug("get successful, no instance found");
@@ -124,6 +129,8 @@ public abstract class PlantillaFacadeEJB extends HibernateTrulyStatelessEJB {
 		} catch (HibernateException re) {
 			log.error("get failed", re);
 			throw new EJBException(re);
+		} finally {
+			this.close(session);
 		}
 
 	}
@@ -136,9 +143,9 @@ public abstract class PlantillaFacadeEJB extends HibernateTrulyStatelessEJB {
 	 */
 	public Plantilla obtenerPlantilla(java.lang.Long id) {
 		log.debug("getting Plantilla instance with id: " + id);
+		Session session = this.getSession();
 		try {
-			Plantilla instance = (Plantilla) this.getSession().get(
-					Plantilla.class, id);
+			Plantilla instance = (Plantilla) session.get(Plantilla.class, id);
 			if (instance == null) {
 				log.debug("get successful, no instance found");
 			} else {
@@ -148,6 +155,8 @@ public abstract class PlantillaFacadeEJB extends HibernateTrulyStatelessEJB {
 		} catch (HibernateException re) {
 			log.error("get failed", re);
 			throw new EJBException(re);
+		} finally {
+			this.close(session);
 		}
 	}
 

--- a/moduls/micropersistence/src/es/caib/gusite/micropersistence/ejb/PlantillaFacadeEJB.java
+++ b/moduls/micropersistence/src/es/caib/gusite/micropersistence/ejb/PlantillaFacadeEJB.java
@@ -149,6 +149,9 @@ public abstract class PlantillaFacadeEJB extends HibernateTrulyStatelessEJB {
 			if (instance == null) {
 				log.debug("get successful, no instance found");
 			} else {
+				// forzar carga de colecciones para poder cerrar la conexión
+				// sin riesgo a LazyInitializationException
+				instance.getPersonalizacionesPlantilla().size();
 				log.debug("get successful, instance found");
 			}
 			return instance;

--- a/moduls/micropersistence/src/es/caib/gusite/micropersistence/ejb/VersionFacadeEJB.java
+++ b/moduls/micropersistence/src/es/caib/gusite/micropersistence/ejb/VersionFacadeEJB.java
@@ -9,6 +9,7 @@ import org.hibernate.HibernateException;
 
 import es.caib.gusite.micromodel.Auditoria;
 import es.caib.gusite.micromodel.Version;
+import es.caib.gusite.micromodel.Plantilla;
 import org.hibernate.Session;
 
 /**
@@ -152,8 +153,8 @@ public abstract class VersionFacadeEJB extends HibernateTrulyStatelessEJB {
 				log.debug("get successful, no instance found");
 			} else {
 				// forzamos la carga de objetos lazy anidados para evitar errores aguas arriba
-				if (instance.getPlantilla() != null) {
-					instance.getPlantilla().getPersonalizacionesPlantilla().size();
+				for (Plantilla plantilla: instance.getPlantillas()) {
+					plantilla.getPersonalizacionesPlantilla().size();
 				}
 				log.debug("get successful, instance found");
 			}

--- a/moduls/micropersistence/src/es/caib/gusite/micropersistence/ejb/VersionFacadeEJB.java
+++ b/moduls/micropersistence/src/es/caib/gusite/micropersistence/ejb/VersionFacadeEJB.java
@@ -122,6 +122,7 @@ public abstract class VersionFacadeEJB extends HibernateTrulyStatelessEJB {
 		Session session = this.getSession();
 		try {
 			List<Version> instances = session.createCriteria(Version.class).list();
+			// ojo: si aguas arriba alguien hace Version.getPlantilla(), fallará por LazyInitializationException
 			if (instances.size() == 0) {
 				log.debug("get successful, no instance found");
 			} else {
@@ -150,6 +151,10 @@ public abstract class VersionFacadeEJB extends HibernateTrulyStatelessEJB {
 			if (instance == null) {
 				log.debug("get successful, no instance found");
 			} else {
+				// forzamos la carga de objetos lazy anidados para evitar errores aguas arriba
+				if (instance.getPlantilla() != null) {
+					instance.getPlantilla().getPersonalizacionesPlantilla().size();
+				}
 				log.debug("get successful, instance found");
 			}
 			return instance;

--- a/moduls/micropersistence/src/es/caib/gusite/micropersistence/ejb/VersionFacadeEJB.java
+++ b/moduls/micropersistence/src/es/caib/gusite/micropersistence/ejb/VersionFacadeEJB.java
@@ -119,9 +119,9 @@ public abstract class VersionFacadeEJB extends HibernateTrulyStatelessEJB {
 	@SuppressWarnings("unchecked")
 	public List<Version> listarVersion() {
 		log.debug("listar Version");
+		Session session = this.getSession();
 		try {
-			List<Version> instances = this.getSession()
-					.createCriteria(Version.class).list();
+			List<Version> instances = session.createCriteria(Version.class).list();
 			if (instances.size() == 0) {
 				log.debug("get successful, no instance found");
 			} else {
@@ -131,6 +131,8 @@ public abstract class VersionFacadeEJB extends HibernateTrulyStatelessEJB {
 		} catch (HibernateException re) {
 			log.error("get failed", re);
 			throw new EJBException(re);
+		} finally {
+			this.close(session);
 		}
 	}
 
@@ -142,9 +144,9 @@ public abstract class VersionFacadeEJB extends HibernateTrulyStatelessEJB {
 	 */
 	public Version obtenerVersion(java.lang.String id) {
 		log.debug("getting Version instance with id: " + id);
+		Session session = this.getSession();
 		try {
-			Version instance = (Version) this.getSession().get(Version.class,
-					id);
+			Version instance = (Version) session.get(Version.class, id);
 			if (instance == null) {
 				log.debug("get successful, no instance found");
 			} else {
@@ -154,6 +156,8 @@ public abstract class VersionFacadeEJB extends HibernateTrulyStatelessEJB {
 		} catch (HibernateException re) {
 			log.error("get failed", re);
 			throw new EJBException(re);
+		} finally {
+			this.close(session);
 		}
 	}
 

--- a/plugins/etc/ehcache.xml
+++ b/plugins/etc/ehcache.xml
@@ -35,12 +35,4 @@
         timeToLiveSeconds="600"
         overflowToDisk="false"/>
 
-
-
-
-
-
-
-
-
 </ehcache>


### PR DESCRIPTION
Esta PR aplica varios cambios que buscan solucionar la fuga de conexiones así como optimizar algunos caminos críticos que provocan un exceso de conexiones a BBDD.

Tras detectar que el problema raíz de los agotamientos del pool era el leak de conexiones abiertas, mantenemos las caché pero las configuramos con un TTL=1s para minimizar su impacto en los usuarios.